### PR TITLE
Changed shuffle order for CEM 31296881

### DIFF
--- a/volvo-cem-cracker.ino
+++ b/volvo-cem-cracker.ino
@@ -78,7 +78,7 @@ struct _cem_params {
   { 31327215, CAN_500KBPS, 3 },
   { 31254749, CAN_500KBPS, 3 },
   { 31254903, CAN_500KBPS, 0 },
-  { 31296881, CAN_500KBPS, 0 },
+  { 31296881, CAN_500KBPS, 3 },
 
 // P2 CEM-B (Brick shaped 1999-2004 with K-line)
   { 8645716, CAN_250KBPS, 0 },


### PR DESCRIPTION
The shuffle order for the CEM 31296881 should be 2, 4, 5, 0, 3, 1 (marked 3 in code). Confirmed on Volvo C70 II 2010 P1 with chassis number 115484.